### PR TITLE
Use minimal proxies for CliptoTokens

### DIFF
--- a/.gas-snapshot
+++ b/.gas-snapshot
@@ -1,3 +1,3 @@
-testRequestCreation() (gas: 2361126)
-testCreatorRegistration() (gas: 2280033)
-testRequestDelivery() (gas: 2523354)
+testRequestCreation() (gas: 290092)
+testCreatorRegistration() (gas: 208999)
+testRequestDelivery() (gas: 375518)

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "lib/openzeppelin-contracts"]
 	path = lib/openzeppelin-contracts
 	url = https://github.com/OpenZeppelin/openzeppelin-contracts
+[submodule "lib/openzeppelin-contracts-upgradeable"]
+	path = lib/openzeppelin-contracts-upgradeable
+	url = https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,11 @@
         "js-tokens": "^4.0.0"
       }
     },
+    "@openzeppelin/contracts-upgradeable": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.4.1.tgz",
+      "integrity": "sha512-84dUN+TBY42D52BzUc4RHxU4KORs8Ys7dj3nH0WX1QKtlS6rrN45gL+sxaotkPdCqFLVLPyj+kd8GfJ4puxVjA=="
+    },
     "@solidity-parser/parser": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.14.0.tgz",

--- a/package.json
+++ b/package.json
@@ -19,5 +19,8 @@
   "scripts": {
     "lint": "prettier --write \"src/**/*.sol\"",
     "solhint:check": "solhint --config ./.solhint.json \"src/**/*.sol\""
+  },
+  "dependencies": {
+    "@openzeppelin/contracts-upgradeable": "^4.4.1"
   }
 }

--- a/src/CliptoExchange.sol
+++ b/src/CliptoExchange.sol
@@ -12,7 +12,7 @@ contract CliptoExchange {
     //////////////////////////////////////////////////////////////*/
 
     /// @dev Address of the Clipto Token implementation
-    address public TOKEN_IMPLEMENTATION;
+    address public immutable TOKEN_IMPLEMENTATION;
 
     constructor(address implementation) {
         TOKEN_IMPLEMENTATION = implementation;

--- a/src/CliptoExchange.sol
+++ b/src/CliptoExchange.sol
@@ -141,4 +141,34 @@ contract CliptoExchange {
 
         emit RefundedRequest(creator, requests[creator][index].requester, index, requests[creator][index].amount);
     }
+
+    /*///////////////////////////////////////////////////////////////
+                              NFT UTILITIES
+    //////////////////////////////////////////////////////////////*/
+
+    /// @dev Deploy a mimimal proxy contract for a user's NFT collection.
+    function deployProxy() internal returns (address proxy) {
+        bytes20 implementation = bytes20(TOKEN_IMPLEMENTATION);
+
+        assembly {
+            // Read a free storage slot
+            let clone := mload(0x40)
+
+            // Store the constructor (10 bytes) + the 10 bytes of execution code that comes before the address
+            mstore(clone, 0x3d602d80600a3d3981f3363d3d373d3d3d363d73000000000000000000000000)
+
+            // Store the 20 bytes behind the clone pointer (where the zeroes start)
+            // 0x14 = 20
+            mstore(add(clone, 0x14), implementation)
+
+            // Store 32 bytes behind the implementation address
+            mstore(add(clone, 0x28), 0x5af43d82803e903d91602b57fd5bf30000000000000000000000000000000000)
+
+            // Use the CREATE opcode to deploy a new contract
+            // Send 0 Ether
+            // The code starts at pointer stored in "clone"
+            // The codesize is 55 bytes (0x37)
+            proxy := create(0, clone, 0x37)
+        }
+    }
 }

--- a/src/CliptoExchange.sol
+++ b/src/CliptoExchange.sol
@@ -32,7 +32,7 @@ contract CliptoExchange {
         /// @dev Minimum cost of a video
         uint256 cost;
         /// @dev address of creator's associated nft collection
-        address token;
+        CliptoToken token;
     }
 
     /// @notice Emitted when a new creator is registered.
@@ -56,8 +56,7 @@ contract CliptoExchange {
     ) external returns (address) {
         require(creators[msg.sender].token == address(0), "Already registered");
 
-        // TODO: Do not deploy a new contract for each creator!
-        address tokenAddress = address(new CliptoToken(creatorName));
+        CliptoToken tokenAddress = new CliptoToken(creatorName);
         creators[msg.sender] = Creator({profileUrl: profileUrl, cost: cost, token: tokenAddress});
 
         // Emit event

--- a/src/CliptoExchange.sol
+++ b/src/CliptoExchange.sol
@@ -8,6 +8,17 @@ import {CliptoToken} from "./CliptoToken.sol";
 /// @dev Exchange contract for Clipto Videos
 contract CliptoExchange {
     /*///////////////////////////////////////////////////////////////
+                                IMMUTABLES
+    //////////////////////////////////////////////////////////////*/
+
+    /// @dev Address of the Clipto Token implementation
+    address public TOKEN_IMPLEMENTATION;
+
+    constructor(address implementation) {
+        TOKEN_IMPLEMENTATION = implementation;
+    }
+
+    /*///////////////////////////////////////////////////////////////
                                 CREATOR STORAGE
     //////////////////////////////////////////////////////////////*/
 

--- a/src/CliptoToken.sol
+++ b/src/CliptoToken.sol
@@ -9,51 +9,66 @@ import {ERC721URIStorage} from "@openzeppelin/contracts/token/ERC721/extensions/
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {Counters} from "@openzeppelin/contracts/utils/Counters.sol";
 
-contract CliptoToken is ERC721Upgradeable {
-    // using Counters for Counters.Counter;
+contract CliptoToken is ERC721("", ""), ERC721Enumerable, ERC721URIStorage {
+    using Counters for Counters.Counter;
 
-    // Counters.Counter private _tokenIdCounter;
+    Counters.Counter private _tokenIdCounter;
+    string internal _name;
+    string internal _symbol;
+    bool internal initalized;
+    address owner;
 
-    function initialize(string memory _creatorName) external initializer {
-        __ERC721_init(string(abi.encodePacked("Clipto - ", _creatorName)), "CTO");
+    function initialize(string memory _creatorName) external {
+        require(!initalized);
+
+        _name = string(abi.encodePacked("Clipto - ", _creatorName));
+        _symbol = "CTO";
+        initalized = true;
+
+        owner = msg.sender;
     }
 
-    function safeMint(address to, string memory data) external {
-        _safeMint(to, 0);
+    function name() public view override returns (string memory) {
+        return _name;
     }
 
-    // // See https://docs.opensea.io/docs/contract-level-metadata
-    // function contractURI() public pure returns (string memory) {
-    //     return "https://clipto.io/contract-metadata.json";
-    // }
+    function symbol() public view override returns (string memory) {
+        return _symbol;
+    }
 
-    // function safeMint(address to, string memory _tokenURI) public onlyOwner {
-    //     _safeMint(to, _tokenIdCounter.current());
-    //     _setTokenURI(_tokenIdCounter.current(), _tokenURI);
+    // See https://docs.opensea.io/docs/contract-level-metadata
+    function contractURI() public pure returns (string memory) {
+        return "https://clipto.io/contract-metadata.json";
+    }
 
-    //     _tokenIdCounter.increment();
-    // }
+    function safeMint(address to, string memory _tokenURI) public {
+        require(msg.sender == owner);
+        _safeMint(to, _tokenIdCounter.current());
+        _setTokenURI(_tokenIdCounter.current(), _tokenURI);
 
-    // /*
-    //  * The following functions are overrides required by Solidity.
-    //  */
-    // function _burn(uint256 tokenId) internal override(ERC721, ERC721URIStorage) {
-    //     super._burn(tokenId);
-    // }
+        _tokenIdCounter.increment();
+    }
 
-    // function tokenURI(uint256 tokenId) public view override(ERC721, ERC721URIStorage) returns (string memory) {
-    //     return super.tokenURI(tokenId);
-    // }
+    /*
+     * The following functions are overrides required by Solidity.
+     */
+    function _burn(uint256 tokenId) internal override(ERC721, ERC721URIStorage) {
+        super._burn(tokenId);
+    }
 
-    // function _beforeTokenTransfer(
-    //     address from,
-    //     address to,
-    //     uint256 tokenId
-    // ) internal override(ERC721, ERC721Enumerable) {
-    //     super._beforeTokenTransfer(from, to, tokenId);
-    // }
+    function tokenURI(uint256 tokenId) public view override(ERC721, ERC721URIStorage) returns (string memory) {
+        return super.tokenURI(tokenId);
+    }
 
-    // function supportsInterface(bytes4 interfaceId) public view override(ERC721, ERC721Enumerable) returns (bool) {
-    //     return super.supportsInterface(interfaceId);
-    // }
+    function _beforeTokenTransfer(
+        address from,
+        address to,
+        uint256 tokenId
+    ) internal override(ERC721, ERC721Enumerable) {
+        super._beforeTokenTransfer(from, to, tokenId);
+    }
+
+    function supportsInterface(bytes4 interfaceId) public view override(ERC721, ERC721Enumerable) returns (bool) {
+        return super.supportsInterface(interfaceId);
+    }
 }

--- a/src/CliptoToken.sol
+++ b/src/CliptoToken.sol
@@ -15,7 +15,11 @@ contract CliptoToken is ERC721Upgradeable {
     // Counters.Counter private _tokenIdCounter;
 
     function initialize(string memory _creatorName) external {
-        __ERC721_init(abi.encodePacked("Clipto - ", _creatorName), "CTO");
+        __ERC721_init(string(abi.encodePacked("Clipto - ", _creatorName)), "CTO");
+    }
+
+    function safeMint(address to, string memory data) external {
+        _safeMint(to, 0);
     }
 
     // // See https://docs.opensea.io/docs/contract-level-metadata

--- a/src/CliptoToken.sol
+++ b/src/CliptoToken.sol
@@ -2,17 +2,21 @@
 pragma solidity 0.8.10;
 
 import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import {ERC721Upgradeable} from "lib/openzeppelin-contracts-upgradeable/contracts/token/ERC721/ERC721Upgradeable.sol";
+
 import {ERC721Enumerable} from "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
 import {ERC721URIStorage} from "@openzeppelin/contracts/token/ERC721/extensions/ERC721URIStorage.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {Counters} from "@openzeppelin/contracts/utils/Counters.sol";
 
-contract CliptoToken is ERC721, ERC721Enumerable, ERC721URIStorage, Ownable {
+contract CliptoToken is ERC721Upgradeable, ERC721Enumerable, ERC721URIStorage, Ownable {
     using Counters for Counters.Counter;
 
     Counters.Counter private _tokenIdCounter;
 
-    constructor(string memory _creatorName) ERC721(string(abi.encodePacked("Clipto - ", _creatorName)), "CTO") {}
+    function initialize(string memory _creatorName) external {
+        __ERC721_init(abi.encodePacked("Clipto - ", _creatorName), "CTO");
+    }
 
     // See https://docs.opensea.io/docs/contract-level-metadata
     function contractURI() public pure returns (string memory) {

--- a/src/CliptoToken.sol
+++ b/src/CliptoToken.sol
@@ -14,7 +14,7 @@ contract CliptoToken is ERC721Upgradeable {
 
     // Counters.Counter private _tokenIdCounter;
 
-    function initialize(string memory _creatorName) external {
+    function initialize(string memory _creatorName) external initializer {
         __ERC721_init(string(abi.encodePacked("Clipto - ", _creatorName)), "CTO");
     }
 

--- a/src/CliptoToken.sol
+++ b/src/CliptoToken.sol
@@ -9,47 +9,47 @@ import {ERC721URIStorage} from "@openzeppelin/contracts/token/ERC721/extensions/
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {Counters} from "@openzeppelin/contracts/utils/Counters.sol";
 
-contract CliptoToken is ERC721Upgradeable, ERC721Enumerable, ERC721URIStorage, Ownable {
-    using Counters for Counters.Counter;
+contract CliptoToken is ERC721Upgradeable {
+    // using Counters for Counters.Counter;
 
-    Counters.Counter private _tokenIdCounter;
+    // Counters.Counter private _tokenIdCounter;
 
     function initialize(string memory _creatorName) external {
         __ERC721_init(abi.encodePacked("Clipto - ", _creatorName), "CTO");
     }
 
-    // See https://docs.opensea.io/docs/contract-level-metadata
-    function contractURI() public pure returns (string memory) {
-        return "https://clipto.io/contract-metadata.json";
-    }
+    // // See https://docs.opensea.io/docs/contract-level-metadata
+    // function contractURI() public pure returns (string memory) {
+    //     return "https://clipto.io/contract-metadata.json";
+    // }
 
-    function safeMint(address to, string memory _tokenURI) public onlyOwner {
-        _safeMint(to, _tokenIdCounter.current());
-        _setTokenURI(_tokenIdCounter.current(), _tokenURI);
+    // function safeMint(address to, string memory _tokenURI) public onlyOwner {
+    //     _safeMint(to, _tokenIdCounter.current());
+    //     _setTokenURI(_tokenIdCounter.current(), _tokenURI);
 
-        _tokenIdCounter.increment();
-    }
+    //     _tokenIdCounter.increment();
+    // }
 
-    /*
-     * The following functions are overrides required by Solidity.
-     */
-    function _burn(uint256 tokenId) internal override(ERC721, ERC721URIStorage) {
-        super._burn(tokenId);
-    }
+    // /*
+    //  * The following functions are overrides required by Solidity.
+    //  */
+    // function _burn(uint256 tokenId) internal override(ERC721, ERC721URIStorage) {
+    //     super._burn(tokenId);
+    // }
 
-    function tokenURI(uint256 tokenId) public view override(ERC721, ERC721URIStorage) returns (string memory) {
-        return super.tokenURI(tokenId);
-    }
+    // function tokenURI(uint256 tokenId) public view override(ERC721, ERC721URIStorage) returns (string memory) {
+    //     return super.tokenURI(tokenId);
+    // }
 
-    function _beforeTokenTransfer(
-        address from,
-        address to,
-        uint256 tokenId
-    ) internal override(ERC721, ERC721Enumerable) {
-        super._beforeTokenTransfer(from, to, tokenId);
-    }
+    // function _beforeTokenTransfer(
+    //     address from,
+    //     address to,
+    //     uint256 tokenId
+    // ) internal override(ERC721, ERC721Enumerable) {
+    //     super._beforeTokenTransfer(from, to, tokenId);
+    // }
 
-    function supportsInterface(bytes4 interfaceId) public view override(ERC721, ERC721Enumerable) returns (bool) {
-        return super.supportsInterface(interfaceId);
-    }
+    // function supportsInterface(bytes4 interfaceId) public view override(ERC721, ERC721Enumerable) returns (bool) {
+    //     return super.supportsInterface(interfaceId);
+    // }
 }

--- a/src/test/CliptoExchange.t.sol
+++ b/src/test/CliptoExchange.t.sol
@@ -10,7 +10,7 @@ contract CliptoExchangeTest is DSTestPlus, IERC721Receiver {
     CliptoExchange internal exchange;
 
     function setUp() external {
-        exchange = new CliptoExchange();
+        exchange = new CliptoExchange(address(new CliptoToken()));
     }
 
     function testCreatorRegistration() public {
@@ -18,12 +18,12 @@ contract CliptoExchangeTest is DSTestPlus, IERC721Receiver {
         address tokenAddress = exchange.registerCreator("Gabriel", "https://arweave.net/0xprofileurl", 1e18);
 
         // Retrieve creator information.
-        (string memory profileUrl, uint256 cost, address token) = exchange.creators(address(this));
+        (string memory profileUrl, uint256 cost, CliptoToken token) = exchange.creators(address(this));
 
         // Ensure the data returned is correct.
         assertEq(profileUrl, "https://arweave.net/0xprofileurl");
         assertEq(cost, 1e18);
-        assertEq(token, tokenAddress);
+        assertEq(address(token), tokenAddress);
     }
 
     function testRequestCreation() public {


### PR DESCRIPTION
Creator registration is 10x more efficient (tests went from well over 2,000,000 gas to 200,000)!

The one problem with this is that, in order to make CliptoToken upgradeable we have to use ERC721Upgradeable which conflicts with our current codebase, so I have commented that out in order for the compiler to function, modifying it shouldn't be too difficult!