### PR TITLE
Minor snipes, add `updateRequest`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,6 +7,3 @@
 [submodule "lib/openzeppelin-contracts"]
 	path = lib/openzeppelin-contracts
 	url = https://github.com/OpenZeppelin/openzeppelin-contracts
-[submodule "lib/openzeppelin-contracts-upgradeable"]
-	path = lib/openzeppelin-contracts-upgradeable
-	url = https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,2 +1,3 @@
 @openzeppelin/=lib/openzeppelin-contracts/
 ds-test/=lib/ds-test/src/
+solmate =lib/solmate/src/

--- a/src/CliptoExchange.sol
+++ b/src/CliptoExchange.sol
@@ -2,11 +2,13 @@
 pragma solidity 0.8.10;
 
 import {CliptoToken} from "./CliptoToken.sol";
+import {Clones} from "@openzeppelin/contracts/proxy/Clones.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 
 /// @title Clipto Exchange
 /// @author Clipto
 /// @dev Exchange contract for Clipto Videos
-contract CliptoExchange {
+contract CliptoExchange is ReentrancyGuard {
     /*///////////////////////////////////////////////////////////////
                                 IMMUTABLES
     //////////////////////////////////////////////////////////////*/
@@ -53,18 +55,15 @@ contract CliptoExchange {
         string memory creatorName,
         string memory profileUrl,
         uint256 cost
-    ) external returns (address) {
+    ) external {
         require(address(creators[msg.sender].token) == address(0), "Already registered");
 
-        CliptoToken token = CliptoToken(deployProxy());
+        CliptoToken token = CliptoToken(Clones.clone(TOKEN_IMPLEMENTATION));
         token.initialize(creatorName);
         creators[msg.sender] = Creator({profileUrl: profileUrl, cost: cost, token: token});
 
         // Emit event
         emit CreatorRegistered(msg.sender, profileUrl, cost, token);
-
-        // Return token address
-        return address(token);
     }
 
     /// @notice Modify a creator details
@@ -115,7 +114,17 @@ contract CliptoExchange {
         emit NewRequest(creator, msg.sender, requests[creator].length, msg.value);
     }
 
-    function deliverRequest(uint256 index, string memory _tokenURI) external {
+    /// @notice Allows adding to the value of a request
+    /// @dev The request's "amount" is increased by msg.value
+    function updateRequest(address creator, uint256 index) external payable {
+        require(msg.sender == requests[creator][index].requester, "only requester may update");
+        requests[creator][index].amount += msg.value;
+
+        // even though this isn't a new request, the event serves the purpose well
+        emit NewRequest(creator, msg.sender, index, requests[creator][index].amount);
+    }
+
+    function deliverRequest(uint256 index, string memory _tokenURI) external nonReentrant {
         require(requests[msg.sender][index].delivered == false, "Request already delivered");
         require(requests[msg.sender][index].refunded == false, "Request already refunded");
 
@@ -132,7 +141,7 @@ contract CliptoExchange {
         );
     }
 
-    function refundRequest(address creator, uint256 index) external {
+    function refundRequest(address creator, uint256 index) external nonReentrant {
         require(requests[creator][index].delivered == false, "Request already delivered");
         require(requests[creator][index].refunded == false, "Request already refunded");
 
@@ -141,35 +150,5 @@ contract CliptoExchange {
         require(sent, "Delivery failed");
 
         emit RefundedRequest(creator, requests[creator][index].requester, index, requests[creator][index].amount);
-    }
-
-    /*///////////////////////////////////////////////////////////////
-                              NFT UTILITIES
-    //////////////////////////////////////////////////////////////*/
-
-    /// @dev Deploy a mimimal proxy contract for a user's NFT collection.
-    function deployProxy() internal returns (address proxy) {
-        bytes20 implementation = bytes20(TOKEN_IMPLEMENTATION);
-
-        assembly {
-            // Read a free storage slot
-            let clone := mload(0x40)
-
-            // Store the constructor (10 bytes) + the 10 bytes of execution code that comes before the address
-            mstore(clone, 0x3d602d80600a3d3981f3363d3d373d3d3d363d73000000000000000000000000)
-
-            // Store the 20 bytes behind the clone pointer (where the zeroes start)
-            // 0x14 = 20
-            mstore(add(clone, 0x14), implementation)
-
-            // Store 32 bytes behind the implementation address
-            mstore(add(clone, 0x28), 0x5af43d82803e903d91602b57fd5bf30000000000000000000000000000000000)
-
-            // Use the CREATE opcode to deploy a new contract
-            // Send 0 Ether
-            // The code starts at pointer stored in "clone"
-            // The codesize is 55 bytes (0x37)
-            proxy := create(0, clone, 0x37)
-        }
     }
 }

--- a/src/CliptoExchange.sol
+++ b/src/CliptoExchange.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.10;
 
 import {CliptoToken} from "./CliptoToken.sol";
 import {Clones} from "@openzeppelin/contracts/proxy/Clones.sol";
-import {ReentrancyGuard} from "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+import {ReentrancyGuard} from "lib/solmate/src/utils/ReentrancyGuard.sol";
 
 /// @title Clipto Exchange
 /// @author Clipto

--- a/src/CliptoToken.sol
+++ b/src/CliptoToken.sol
@@ -2,8 +2,6 @@
 pragma solidity 0.8.10;
 
 import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
-import {ERC721Upgradeable} from "lib/openzeppelin-contracts-upgradeable/contracts/token/ERC721/ERC721Upgradeable.sol";
-
 import {ERC721Enumerable} from "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
 import {ERC721URIStorage} from "@openzeppelin/contracts/token/ERC721/extensions/ERC721URIStorage.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";

--- a/src/test/CliptoExchange.t.sol
+++ b/src/test/CliptoExchange.t.sol
@@ -28,7 +28,6 @@ contract CliptoExchangeTest is DSTestPlus, IERC721Receiver {
         // Ensure the data returned is correct.
         assertEq(profileUrl, "https://arweave.net/0xprofileurl");
         assertEq(cost, 1e18);
-        assertEq(address(token), tokenAddress);
     }
 
     function testRequestCreation() public {

--- a/src/test/CliptoExchange.t.sol
+++ b/src/test/CliptoExchange.t.sol
@@ -6,6 +6,26 @@ import {CliptoToken} from "../CliptoToken.sol";
 import {DSTestPlus} from "lib/solmate/src/test/utils/DSTestPlus.sol";
 import {IERC721Receiver} from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
 
+struct Creator {
+    /// @dev Creator's profile url on arweave
+    string profileUrl;
+    /// @dev Minimum cost of a video
+    uint256 cost;
+    /// @dev address of creator's associated nft collection
+    CliptoToken token;
+}
+
+struct Request {
+    /// @dev Address of the requester
+    address requester;
+    /// @dev Amount of L1 token set for the request
+    uint256 amount;
+    /// @dev Whether the request is delivered
+    bool delivered;
+    /// @dev flag to indicate whether the request was refunded
+    bool refunded;
+}
+
 contract CliptoExchangeTest is DSTestPlus, IERC721Receiver {
     CliptoExchange internal exchange;
 
@@ -15,10 +35,15 @@ contract CliptoExchangeTest is DSTestPlus, IERC721Receiver {
 
     function testCreatorRegistration() public {
         // Register creator.
-        address tokenAddress = exchange.registerCreator("Gabriel", "https://arweave.net/0xprofileurl", 1e18);
+        exchange.registerCreator(
+            "Gabriel", 
+            "https://arweave.net/0xprofileurl", 
+            1e18
+        );
 
         // Retrieve creator information.
         (string memory profileUrl, uint256 cost, CliptoToken token) = exchange.creators(address(this));
+        address tokenAddress = address(token);
 
         // Ensure the data returned is correct.
         assertEq(profileUrl, "https://arweave.net/0xprofileurl");

--- a/src/test/CliptoExchange.t.sol
+++ b/src/test/CliptoExchange.t.sol
@@ -6,26 +6,6 @@ import {CliptoToken} from "../CliptoToken.sol";
 import {DSTestPlus} from "lib/solmate/src/test/utils/DSTestPlus.sol";
 import {IERC721Receiver} from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
 
-struct Creator {
-    /// @dev Creator's profile url on arweave
-    string profileUrl;
-    /// @dev Minimum cost of a video
-    uint256 cost;
-    /// @dev address of creator's associated nft collection
-    CliptoToken token;
-}
-
-struct Request {
-    /// @dev Address of the requester
-    address requester;
-    /// @dev Amount of L1 token set for the request
-    uint256 amount;
-    /// @dev Whether the request is delivered
-    bool delivered;
-    /// @dev flag to indicate whether the request was refunded
-    bool refunded;
-}
-
 contract CliptoExchangeTest is DSTestPlus, IERC721Receiver {
     CliptoExchange internal exchange;
 


### PR DESCRIPTION
This PR has a few very minor changes. Feel free to reject some and ask for others - I'm happy to make a new PR based on the general consensus, but figured it would be better if I just pushed what I have so it's there is it's wanted.

Changes:
* removed the return value of `newRequest` (very minor gas savings)
* added OZ's reentrancy shield on `deliverRequest` and `refundRequest` to prevent `call`s from being used for reentrancy
* removed the `openzeppelin-contracts-upgradeable` library and its (unused) import from `CliptoToken`
* removed the `createProxy` function and replaced it with OZ's library for doing the same. Rationale: while the `createProxy` function was, afaict, coded correctly, using OZ's function allows any potential user auditing the code to quickly understand that our implementation has OZ's seal on it. For the record, their implementation does cost ~20 gas more, though.

* a function for adding value to a request has been made, named `updateRequest`. The assumption is that the possibility exists that a requester may make a request with a price lower than what the creator thinks should be the price for this specific request (eg, reciting the entire Ethereum whitepaper). This function will allow the requester to add value to a request in order to align with the creator's price quote for this specific request. This may not be a valid assumption - we might be assuming that requests are only made on-chian once a creator has agreed to a price. If that is the case, this function should be removed.