### PR TITLE
yolo adding 2981 and 4494

### DIFF
--- a/src/interfaces/IERC2981.sol
+++ b/src/interfaces/IERC2981.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.10;
+
+import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+
+// ///
+// /// @dev Interface for the NFT Royalty Standard
+// ///
+interface IERC2981 is IERC165 {
+    /// ERC165 bytes to add to interface array - set in parent contract
+    /// implementing this standard
+    ///
+    /// bytes4(keccak256("royaltyInfo(uint256,uint256)")) == 0x2a55205a
+    /// bytes4 private constant _INTERFACE_ID_ERC2981 = 0x2a55205a;
+    /// _registerInterface(_INTERFACE_ID_ERC2981);
+
+    /// @notice Called with the sale price to determine how much royalty
+    //          is owed and to whom.
+    /// @param _tokenId - the NFT asset queried for royalty information
+    /// @param _salePrice - the sale price of the NFT asset specified by _tokenId
+    /// @return receiver - address of who should be sent the royalty payment
+    /// @return royaltyAmount - the royalty payment amount for _salePrice
+    function royaltyInfo(uint256 _tokenId, uint256 _salePrice)
+        external
+        view
+        returns (address receiver, uint256 royaltyAmount);
+}

--- a/src/interfaces/IERC4494.sol
+++ b/src/interfaces/IERC4494.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.10;
+
+import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+
+///
+/// @dev Interface for token permits for ERC721
+///
+interface IERC4494 is IERC165 {
+  /// ERC165 bytes to add to interface array - set in parent contract
+  ///
+  /// _INTERFACE_ID_ERC4494 = 0x5604e225
+  /// @notice Function to approve by way of owner signature
+  /// @param spender the address to approve
+  /// @param tokenId the index of the NFT to approve the spender on
+  /// @param deadline a timestamp expiry for the permit
+  /// @param sig a traditional or EIP2098 signature
+  function permit(address spender, uint256 tokenId, uint256 deadline, bytes memory sig) external;
+  /// @notice Returns the nonce of an NFT - useful for creating permits
+  /// @param tokenId the index of the NFT to get the nonce of
+  /// @return the uint256 representation of the nonce
+  function nonces(uint256 tokenId) external view returns(uint256);
+  /// @notice Returns the domain separator used in the encoding of the signature for permits, as defined by EIP712
+  /// @return the bytes32 domain separator
+  function DOMAIN_SEPARATOR() external view returns(bytes32);
+}

--- a/src/test/CliptoExchange.t.sol
+++ b/src/test/CliptoExchange.t.sol
@@ -23,7 +23,6 @@ contract CliptoExchangeTest is DSTestPlus, IERC721Receiver {
 
         // Retrieve creator information.
         (string memory profileUrl, uint256 cost, CliptoToken token) = exchange.creators(address(this));
-        address tokenAddress = address(token);
 
         // Ensure the data returned is correct.
         assertEq(profileUrl, "https://arweave.net/0xprofileurl");


### PR DESCRIPTION
This PR adds ERCs [2981](https://eips.ethereum.org/EIPS/eip-2981) and [4494](https://eips.ethereum.org/EIPS/eip-4494). This means a permit system for transfers and also a royalty system. **There are not yet tests included for these additions.**

4494 is currently only in Draft, meaning that it may change. My rationale for including as-is is that the contracts here are likely to change even sooner.