### PR TITLE
Generic contract cleanup after review

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@ clipto is a decentralized service that lets users hire creators to make personal
 ## Contributing
 
 ### Contract Setup
-Run `make` to install the needed dependencies
- - [Install dapptools](https://github.com/dapphub/dapptools)
+ - [Install dapptools](https://github.com/dapphub/dapptools) / [on macOS ARM](https://roycewells.io/writing/dapptools-m1/)
  - nix-env is a prerequiste to dapptools so you may not need to install nix-env.
- - You need to install `nix-env`. [Mac install](https://wickedchicken.github.io/post/macos-nix-setup/)
+ - You need to install `nix-env`. [macOS install](https://wickedchicken.github.io/post/macos-nix-setup/)
 
- 1. `dapp build`
-   This will the abi for the contract in `./out`. If you make changes and you never build or test (testing automatically builds) and proceed to the next step, you might be using an older version of a contract resulting in inexpected behavior.
- 2. Terminal 1: `dapp testnet`
+ 1. `make`
+ 2. `dapp build`
+   This will output all the ABIs for the contracts in `./out`. If you make changes and you never build or test (testing automatically builds) and proceed to the next step, you might be using an older version of a contract resulting in inexpected behavior.
+ 3. Terminal 1: `dapp testnet`
   This will output your contract settings:
 ```
 dapp-testnet:   RPC URL: http://127.0.0.1:8545
@@ -24,8 +24,8 @@ dapp-testnet:   Account: 0x20c7ec45C46981fB1D10033c166D852EfFf206bc (default)
 ```
 
 You want to copy the address of `Account` for the next step.
- 3. Terminal 2: `export ETH_FROM=<Account address here>`
- 4. Terminal 2: `./scripts/deploy.sh`. If it prompts you for a password, testnet password is always nothing. So just press enter. When the script is done and is successful, the green text
+ 4. Terminal 2: `export ETH_FROM=<Account address here>`
+ 5. Terminal 2: `./scripts/deploy.sh`. If it prompts you for a password, testnet password is always nothing. So just press enter. When the script is done and is successful, the green text
  ```
  CliptoExchange deployed at: <address>
  ``` 

--- a/src/CliptoExchange.sol
+++ b/src/CliptoExchange.sol
@@ -113,15 +113,14 @@ contract CliptoExchange is ReentrancyGuard {
     /// @dev The creator receives funds from contract specified by the Request struct and 
     ///     the requester receives an NFT in exchange
     function deliverRequest(uint256 index, string memory tokenURI) external nonReentrant {
-        // Store the request in memory.
-        Request memory request = requests[msg.sender][index];
+        Request storage request = requests[msg.sender][index];
 
         // Ensure that the request has not been fulfilled.
         require(!request.fulfilled, "Request already fulfilled");
 
         // Mint the token to the requester and mark the request as fulfilled.
         creators[msg.sender].safeMint(request.requester, tokenURI);
-        requests[msg.sender][index].fulfilled = true;
+        request.fulfilled = true;
 
         // Ensure the transfer is successful.
         (bool sent, ) = msg.sender.call{value: request.amount}("");
@@ -134,16 +133,15 @@ contract CliptoExchange is ReentrancyGuard {
     /// @notice Allows the requester to be refunded if the creator fails to deliver
     /// @dev The requester received funds from the contract as specified by the Request struct
     function refundRequest(address creator, uint256 index) external nonReentrant {
-        // Store the request in memory.
-        Request memory request = requests[creator][index];
+        Request storage request = requests[creator][index];
         // Ensure that only the requester can ask for a refund
         require(request.requester == msg.sender, "Not requester");
         // Ensure that the request has not been fulfilled.
         require(!request.fulfilled, "Request already delivered");
 
         // Refund the request.
-        requests[creator][index].fulfilled = true;
-        (bool sent, ) = requests[creator][index].requester.call{value: requests[creator][index].amount}("");
+        request.fulfilled = true;
+        (bool sent, ) = request.requester.call{value: requests[creator][index].amount}("");
         require(sent, "Delivery failed");
 
         // Emit the refunded request value.

--- a/src/CliptoExchange.sol
+++ b/src/CliptoExchange.sol
@@ -61,7 +61,7 @@ contract CliptoExchange is ReentrancyGuard {
         address requester;
         /// @dev Amount of L1 token set for the request
         uint256 amount;
-        /// @dev Boolean indicating whether the request has been fulfilled/refunded.
+        /// @dev Boolean where false = not yet started and true = fulfilled or refunded.
         bool fulfilled;
     }
 

--- a/src/CliptoExchange.sol
+++ b/src/CliptoExchange.sol
@@ -145,6 +145,6 @@ contract CliptoExchange is ReentrancyGuard {
         require(sent, "Delivery failed");
 
         // Emit the refunded request value.
-        emit RefundedRequest(creator, request.requester, index, request.amount);
+        emit RefundedRequest(creator, request.requester, request.amount, index);
     }
 }

--- a/src/CliptoToken.sol
+++ b/src/CliptoToken.sol
@@ -25,12 +25,12 @@ contract CliptoToken is ERC721("", ""), ERC721Enumerable, ERC721URIStorage, IERC
     string internal _symbol;
     bool internal initalized;
     address owner;
-    /// @notice rate * 10,000, default: 5%
-    uint256 royaltyRate = 500;
-    uint256 scale = 1e5;
+    uint256 royaltyRate;
+    uint256 scale;
 
     event RoyaltyRateSet(uint256 newRate);
 
+    /// @dev all variables must be set here so the minimal proxy will work
     function initialize(string memory _creatorName) external {
         require(!initalized);
 
@@ -42,6 +42,10 @@ contract CliptoToken is ERC721("", ""), ERC721Enumerable, ERC721URIStorage, IERC
 
         nameHash = keccak256(bytes(_name));
         versionHash = keccak256(bytes("0.0.1"));
+
+        /// @notice rate * 10,000, default: 5%
+        royaltyRate = 50_000;
+        scale = 1e5;
     }
 
     function name() public view override returns (string memory) {
@@ -67,7 +71,7 @@ contract CliptoToken is ERC721("", ""), ERC721Enumerable, ERC721URIStorage, IERC
     ///   for example, 10% would be input as 100,000
     function setRoyaltyRate(uint256 newRate) external {
         require(msg.sender == owner, "only owner may set rate");
-        require(newRate <= 50_000, "royalty rate must be <50%");
+        require(newRate <= 500_000, "royalty rate must be <50%");
         royaltyRate = newRate;
         emit RoyaltyRateSet(newRate);
     }

--- a/src/CliptoToken.sol
+++ b/src/CliptoToken.sol
@@ -24,9 +24,9 @@ contract CliptoToken is ERC721("", ""), ERC721Enumerable, ERC721URIStorage, IERC
     string internal _name;
     string internal _symbol;
     bool internal initalized;
-    address owner;
-    uint256 royaltyRate;
-    uint256 scale;
+    address public owner;
+    uint256 public royaltyRate;
+    uint256 public scale;
 
     event RoyaltyRateSet(uint256 newRate);
 
@@ -43,9 +43,9 @@ contract CliptoToken is ERC721("", ""), ERC721Enumerable, ERC721URIStorage, IERC
         nameHash = keccak256(bytes(_name));
         versionHash = keccak256(bytes("0.0.1"));
 
-        /// @notice rate * 10,000, default: 5%
+        /// @notice rate * 1,000,000, default: 5%
         royaltyRate = 50_000;
-        scale = 1e5;
+        scale = 1e6;
     }
 
     function name() public view override returns (string memory) {
@@ -62,6 +62,8 @@ contract CliptoToken is ERC721("", ""), ERC721Enumerable, ERC721URIStorage, IERC
     }
 
     function royaltyInfo(uint256 tokenId, uint256 salePrice) external view returns (address, uint256) {
+        // salePrice * royaltyRate will overflow as salePrice approaches uint256
+        // but this is impossible as MATIC or AVAX tokens in circulation is < uint156
         uint256 royaltyAmount = (salePrice * royaltyRate) / scale;
         return (owner, royaltyAmount);
     }

--- a/src/test/CliptoExchange.t.sol
+++ b/src/test/CliptoExchange.t.sol
@@ -139,6 +139,19 @@ contract CliptoExchangeTest is DSTestPlus, IERC721Receiver {
         }
     }
 
+    // check if royalty info is correct
+    function test_royaltyInfo(uint256 price) public {
+        test_creatorRegistration();
+
+        // Amount of MATIC tokens is not more than 10 billion
+        if (price < 10_000_000_000e18) {
+            CliptoToken token = CliptoToken(address(exchange.creators(address(this))));
+            uint256 ret;
+            (, ret) = token.royaltyInfo(0, price);
+            assertEq(ret, price * token.royaltyRate() / token.scale());
+        }
+    }
+
     function onERC721Received(
         address,
         address,


### PR DESCRIPTION
The commit messages should explain each change clearly. 

On commit "use storage for requests - cheaper gas and cleaner code":
After using `storage` in `deliverRequest` and `refundRequest` gas changed as follows:
```
[PASS] test_requestRefund() (gas: 303237)
[PASS] test_requestDelivery() (gas: 442188)
```
to 
```
[PASS] test_requestRefund() (gas: 302629)
[PASS] test_requestDelivery() (gas: 441964)
```
And I think it reads cleaner too.