### PR TITLE
Make token address and token id conspicuous

### DIFF
--- a/src/CliptoExchange.sol
+++ b/src/CliptoExchange.sol
@@ -70,20 +70,52 @@ contract CliptoExchange is ReentrancyGuard {
     /// @param requester Address of the requester.
     /// @param amount Amount paid for the request.
     /// @param index Index of the request in the creator's array of tokens.
-    event NewRequest(address indexed creator, address indexed requester, uint256 amount, uint256 index);
+    event NewRequest(
+        address indexed creator, 
+        address indexed requester, 
+        uint256 amount, 
+        uint256 index
+    );
 
     /// @notice Emitted when a request is updated.
     /// @param creator Address of the creator.
     /// @param requester Address of the requester.
     /// @param amountIncreased Amount increased in the request.
     /// @param index Index of the request in the creator's array of tokens.
-    event RequestUpdated(address indexed creator, address indexed requester, uint256 amountIncreased, uint256 index);
+    event RequestUpdated(
+        address indexed creator, 
+        address indexed requester, 
+        uint256 amountIncreased, 
+        uint256 index
+    );
 
     /// @notice Emitted when a request is delivered
-    event DeliveredRequest(address indexed creator, address indexed requester, uint256 amount, uint256 index);
+    /// @param creator Address of the creator.
+    /// @param requester Address of the requester.
+    /// @param amount Amount in the request.
+    /// @param index Index of the request in the creator's array of tokens.
+    /// @param tokenAddress address of the creator token contract
+    /// @param tokenId id of the of the NFT 
+    event DeliveredRequest(
+        address indexed creator, 
+        address indexed requester, 
+        uint256 amount, 
+        uint256 index,
+        address tokenAddress,
+        uint256 tokenId
+    );
 
     /// @notice Emitted when a request is refunded
-    event RefundedRequest(address indexed creator, address indexed requester, uint256 amount, uint256 index);
+    /// @param creator Address of the creator.
+    /// @param requester Address of the requester.
+    /// @param amount Amount in the request.
+    /// @param index Index of the request in the creator's array of tokens.
+    event RefundedRequest(
+        address indexed creator, 
+        address indexed requester, 
+        uint256 amount, 
+        uint256 index
+    );
 
     /// @notice Create a new request.
     /// @dev The request's "amount" value is the callvalue
@@ -119,6 +151,7 @@ contract CliptoExchange is ReentrancyGuard {
         require(!request.fulfilled, "Request already fulfilled");
 
         // Mint the token to the requester and mark the request as fulfilled.
+        uint256 tokenId = creators[msg.sender].tokenIdCounter();
         creators[msg.sender].safeMint(request.requester, tokenURI);
         request.fulfilled = true;
 
@@ -127,7 +160,14 @@ contract CliptoExchange is ReentrancyGuard {
         require(sent, "Delivery failed");
 
         // Emit the delivered request value.
-        emit DeliveredRequest(msg.sender, request.requester, request.amount, index);
+        emit DeliveredRequest(
+            msg.sender, 
+            request.requester, 
+            request.amount, 
+            index,
+            address(creators[msg.sender]),
+            tokenId
+        );
     }
 
     /// @notice Allows the requester to be refunded if the creator fails to deliver

--- a/src/CliptoToken.sol
+++ b/src/CliptoToken.sol
@@ -7,20 +7,17 @@ import {ERC721URIStorage} from "@openzeppelin/contracts/token/ERC721/extensions/
 import {SignatureChecker} from "@openzeppelin/contracts/utils/cryptography/SignatureChecker.sol";
 import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
-import {Counters} from "@openzeppelin/contracts/utils/Counters.sol";
 import {IERC2981, IERC165} from "./interfaces/IERC2981.sol";
 import {IERC4494} from "./interfaces/IERC4494.sol";
 
 contract CliptoToken is ERC721("", ""), ERC721Enumerable, ERC721URIStorage, IERC2981, IERC4494 {
-    using Counters for Counters.Counter;
-
     /// @dev Value is equal to keccak256("Permit(address spender,uint256 tokenId,uint256 nonce,uint256 deadline)");
     bytes32 public constant PERMIT_TYPEHASH = 0x49ecf333e5b8c95c40fdafc95c1ad136e8914a8fb55e9dc8bb01eaa83a2df9ad;
     bytes32 internal nameHash;
     bytes32 internal versionHash;
     mapping(uint256 => uint256) private _nonces;
 
-    Counters.Counter private _tokenIdCounter;
+    uint256 public tokenIdCounter = 0;
     string internal _name;
     string internal _symbol;
     bool internal initalized;
@@ -80,10 +77,10 @@ contract CliptoToken is ERC721("", ""), ERC721Enumerable, ERC721URIStorage, IERC
 
     function safeMint(address to, string memory _tokenURI) public {
         require(msg.sender == owner);
-        _safeMint(to, _tokenIdCounter.current());
-        _setTokenURI(_tokenIdCounter.current(), _tokenURI);
+        _safeMint(to, tokenIdCounter);
+        _setTokenURI(tokenIdCounter, _tokenURI);
 
-        _tokenIdCounter.increment();
+        tokenIdCounter = tokenIdCounter + 1;
     }
 
     /*


### PR DESCRIPTION
Changes 
1. Added tokenAddress and tokenId in the DeliveredRequest event
```solidity
    event DeliveredRequest(
        address indexed creator, 
        address indexed requester, 
        uint256 amount, 
        uint256 index,
        address tokenAddress,
        uint256 tokenId
    );
```

2. Removed Counters library and made tokenIdCounter public
```solidity
uint256 public tokenIdCounter = 0;
```